### PR TITLE
Update build hooks to 0.8.0 and use $(configh) declaratively

### DIFF
--- a/configure.lua
+++ b/configure.lua
@@ -1,33 +1,25 @@
 ---
---- This script is used as a before_build hook for luarocks-build-hooks.
---- It checks whether the current platform is supported and expands glob
---- patterns in rockspec.build.modules[*].sources so the LuaRocks builtin
---- backend (which does not support wildcards natively) can compile them.
+--- This script runs as a before_build hook for luarocks-build-hooks.
+--- After the $(configh) hook has populated rockspec.build.modules.kqueue
+--- .configh.report, decide which implementation directory to symlink into
+--- ./impl, and expand glob patterns in modules.kqueue.sources so the
+--- builtin backend (which does not natively support wildcards) can compile
+--- the resulting source list.
 ---
 local rockspec = ...
 
-local configh = require('configh')
-local supported = true
-local cc = os.getenv('CC') or
-               (rockspec and rockspec.variables and rockspec.variables.CC)
-local cfgh = configh(cc)
-cfgh:output_status(true)
-for header, funcs in pairs({
-    ['sys/event.h'] = {
-        'kevent',
-    },
-}) do
-    if not cfgh:check_header(header) then
-        supported = false
-    else
-        for _, func in ipairs(funcs) do
-            cfgh:check_func(header, func)
-        end
-    end
-end
-assert(cfgh:flush('src/config.h'))
+local kqueue = rockspec and rockspec.build and rockspec.build.modules and
+                   rockspec.build.modules.kqueue
+assert(kqueue, 'rockspec.build.modules.kqueue not found')
 
--- create symbolic link to src/ or nosup/ directory
+-- The $(configh) hook stores the probe results in kqueue.configh.report.
+-- Treat the platform as "supported" only when sys/event.h exists and
+-- exposes the kevent function.
+local report = kqueue.configh and kqueue.configh.report
+local probe = report and report['sys/event.h']
+local supported = probe and probe.is_exists and probe.kevent or false
+
+-- create a symbolic link to ./src/ or ./nosup/ as ./impl
 local function create_symlink(srcdir)
     os.remove('./impl')
     local cmd = ('ln -sf %s impl'):format(srcdir)
@@ -36,29 +28,26 @@ local function create_symlink(srcdir)
 end
 create_symlink(supported and 'src/' or 'nosup/')
 
--- expand glob patterns in modules.kqueue.sources so the builtin backend
--- can compile them (LuaRocks builtin does not support wildcards natively)
-if rockspec and rockspec.build and rockspec.build.modules then
-    local kqueue = rockspec.build.modules.kqueue
-    local sources = kqueue and kqueue.sources
-    if type(sources) == 'string' then
-        sources = {
-            sources,
-        }
-    end
-    if type(sources) == 'table' then
-        local expanded = {}
-        for _, src in ipairs(sources) do
-            if src:find('[*?]') then
-                local pipe = assert(io.popen('ls ' .. src))
-                for file in pipe:lines() do
-                    expanded[#expanded + 1] = file
-                end
-                pipe:close()
-            else
-                expanded[#expanded + 1] = src
+-- expand glob patterns in kqueue.sources so the builtin backend can
+-- compile them (LuaRocks builtin does not support wildcards natively)
+local sources = kqueue.sources
+if type(sources) == 'string' then
+    sources = {
+        sources,
+    }
+end
+if type(sources) == 'table' then
+    local expanded = {}
+    for _, src in ipairs(sources) do
+        if src:find('[*?]') then
+            local pipe = assert(io.popen('ls ' .. src))
+            for file in pipe:lines() do
+                expanded[#expanded + 1] = file
             end
+            pipe:close()
+        else
+            expanded[#expanded + 1] = src
         end
-        kqueue.sources = expanded
     end
+    kqueue.sources = expanded
 end

--- a/rockspecs/kqueue-dev-1.rockspec
+++ b/rockspecs/kqueue-dev-1.rockspec
@@ -14,20 +14,18 @@ dependencies = {
     "lua >= 5.1",
 }
 build_dependencies = {
-    "luarocks-build-hooks >= 0.2.0",
-    "configh >= 0.2.0",
+    "luarocks-build-hooks >= 0.8.0",
 }
 build = {
     type = "hooks",
     before_build = {
-        "configure.lua",
+        "$(configh)",
         "$(extra-vars)",
+        "configure.lua",
     },
-    -- extra values to append to CFLAGS
     extra_variables = {
         CFLAGS = "-Wall -Wno-trigraphs -Wmissing-field-initializers -Wreturn-type -Wmissing-braces -Wparentheses -Wno-switch -Wunused-function -Wunused-label -Wunused-parameter -Wunused-variable -Wunused-value -Wuninitialized -Wunknown-pragmas -Wshadow -Wsign-compare",
     },
-    -- appends --coverage to CFLAGS and LIBFLAG when KQUEUE_COVERAGE=1
     conditional_variables = {
         KQUEUE_COVERAGE = {
             CFLAGS = "--coverage",
@@ -36,12 +34,23 @@ build = {
     },
     modules = {
         kqueue = {
-            -- glob pattern expanded by configure.lua hook at build time
-            sources = {
-                "impl/*.c",
-            },
+            -- glob patterns expanded by configure.lua hook at build time
+            sources = "impl/*.c",
             incdirs = {
                 "src",
+            },
+            configh = {
+                cc = "$(CC)",
+                output = "src/config.h",
+                output_status = true,
+                headers = {
+                    "sys/event.h",
+                },
+                funcs = {
+                    ["sys/event.h"] = {
+                        "kevent",
+                    },
+                },
             },
         },
     },


### PR DESCRIPTION
Bump luarocks-build-hooks dependency to >= 0.8.0 and move the sys/event.h / kevent probe spec into rockspec.build.modules.kqueue.configh so the platform check is declarative.

configure.lua is now a thin consumer of build.modules.kqueue.configh.report; it still owns the impl symlink decision (src/ vs nosup/) and the source-glob expansion since neither has a built-in hook equivalent.